### PR TITLE
Improve lint formatting checks on CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,32 @@
-# Version: 4.1.1 (Using https://semver.org/)
-# Updated: 2022-05-23
-# See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
-# See https://github.com/RehanSaeed/EditorConfig for updates to this file.
+##########################################
+# Copyright & License Information
+##########################################
+#
+# Copyright (c) 2025 Mike Schulze
+# MIT License - See LICENSE file in the repository root for full license text
+#
+# This .editorconfig file is part of the GdUnit4Net project and is licensed
+# under the MIT License. You may obtain a copy of the License at:
+# https://github.com/MikeSchulze/gdUnit4Net/blob/master/LICENSE
+#
+# This configuration provides consistent code formatting and style rules
+# for the GdUnit4Net C# test framework across different editors and IDEs.
+#
+# For more information about EditorConfig, visit: https://editorconfig.org
+# For GdUnit4Net documentation, visit: https://github.com/MikeSchulze/gdUnit4Net
+#
+##########################################
+
+
+# Version: 5.0.0 (GdUnit4 Consolidated - C# 12)
+# Updated: 2025-06-15
+# Consolidated configuration with C# 12 features enabled
 # See http://EditorConfig.org for more information about .editorconfig files.
 
 ##########################################
 # Common Settings
 ##########################################
 
-# This file is the top-most EditorConfig file
 root = true
 
 # All Files
@@ -19,11 +37,7 @@ indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
 max_line_length = 180
-# Roslynator settings for line length
-roslynator_max_line_length = max_line_length
-resharper_wrap_lines = true
-resharper_hard_wrap_line_length = max_line_length
-csharp_max_line_length = max_line_length
+end_of_line = lf
 
 ##########################################
 # File Extension Settings
@@ -48,9 +62,11 @@ indent_size = 2
 # YAML Files
 [*.{yml,yaml}]
 indent_size = 2
+end_of_line = lf
 
 # Markdown Files
 [*.{md,mdx}]
+indent_size = 2
 trim_trailing_whitespace = false
 
 # Web Files
@@ -70,67 +86,38 @@ end_of_line = lf
 indent_style = tab
 
 ##########################################
-# Default .NET Code Style Severities
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/configuration-options#scope
+# .NET Code Style and Analysis
 ##########################################
 
 [*.{cs,csx,cake,vb,vbx}]
-# Default Severity for all .NET Code Style rules below
+# Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = warning
 
 ##########################################
-# Language Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# Language Rules - .NET Style Rules
 ##########################################
 
-# .NET Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
-[*.{cs,csx,cake,vb,vbx}]
-# "this." and "Me." qualifiers
-dotnet_style_qualification_for_field = true : warning
-dotnet_style_qualification_for_property = true : warning
-dotnet_style_qualification_for_method = true : warning
-dotnet_style_qualification_for_event = true : warning
+# "this." and "Me." qualifiers (GdUnit4 preference: disabled)
+dotnet_style_qualification_for_field = false : warning
+dotnet_style_qualification_for_property = false : warning
+dotnet_style_qualification_for_method = false : warning
+dotnet_style_qualification_for_event = false : warning
 
-# Format document on save - for JetBrains Rider
-resharper_apply_on_save = true
-
-
-# Member ordering
-resharper_member_order = accessibility, kind
-resharper_member_modifier_order = internal static, protected static, private static, static, internal, protected, private
-resharper_kind_order = constant, field, constructor, destructor, delegate, event, enum, interface, property, indexer, operator, method, struct, class
-resharper_accessibility_order = public, internal, protected, private
-
-resharper_arrange_member_access_first = true
-resharper_arrange_static_member_qualifier = true
-resharper_arrange_type_member_modifiers = true
-resharper_arrange_type_modifiers = true
-
-# Force member reordering to be active
-resharper_member_reordering_patterns = true
-
-# Make sure ReSharper member ordering is enabled
-resharper_apply_member_ordering_pattern = true
-
-# Sort using directives
-dotnet_sort_system_directives_first = true
-dotnet_separate_import_directive_groups = true
-
-
-# Language keywords instead of framework type names for type references
+# Language keywords vs framework types
 dotnet_style_predefined_type_for_locals_parameters_members = true : warning
 dotnet_style_predefined_type_for_member_access = true : warning
+
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = always : warning
+dotnet_style_require_accessibility_modifiers = for_non_interface_members : warning
 csharp_preferred_modifier_order = public, private, protected, internal, required, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async : warning
-visual_basic_preferred_modifier_order = Partial, Default, Private, Protected, Public, Friend, NotOverridable, Overridable, MustOverride, Overloads, Overrides, MustInherit, NotInheritable, Static, Shared, Shadows, ReadOnly, WriteOnly, Dim, Const, WithEvents, Widening, Narrowing, Custom, Async : warning
 dotnet_style_readonly_field = true : warning
+
 # Parentheses preferences
 dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_other_binary_operators = always_for_clarity : warning
 dotnet_style_parentheses_in_other_operators = never_if_unnecessary : warning
+
 # Expression-level preferences
 dotnet_style_object_initializer = true : warning
 dotnet_style_collection_initializer = true : warning
@@ -139,34 +126,45 @@ dotnet_style_prefer_inferred_tuple_names = true : warning
 dotnet_style_prefer_inferred_anonymous_type_member_names = true : warning
 dotnet_style_prefer_auto_properties = true : warning
 dotnet_style_prefer_conditional_expression_over_assignment = false : suggestion
-dotnet_diagnostic.IDE0045.severity = suggestion
 dotnet_style_prefer_conditional_expression_over_return = false : suggestion
-dotnet_diagnostic.IDE0046.severity = suggestion
 dotnet_style_prefer_compound_assignment = true : warning
 dotnet_style_prefer_simplified_interpolation = true : warning
 dotnet_style_prefer_simplified_boolean_expressions = true : warning
+
 # Null-checking preferences
 dotnet_style_coalesce_expression = true : warning
 dotnet_style_null_propagation = true : warning
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true : warning
-# File header preferences
-# file_header_template = <copyright file="{fileName}" company="PROJECT-AUTHOR">\n© PROJECT-AUTHOR\n</copyright>
-# If you use StyleCop, you'll need to disable SA1636: File header copyright text should match.
-dotnet_diagnostic.SA1633.severity = none
 
-# Set C# new line preferences
-# Controls placement of binary operators when wrapping expressions
-# Place operators at the beginning of the line (Rider/ReSharper specific setting)
+# Organize using directives
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = true
+
+# Namespace options
+dotnet_style_namespace_match_folder = true : suggestion
+
+# Operator placement
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
-csharp_new_line_before_binary_operators = false
 
-# C# Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+##########################################
+# C# 12 Specific Language Rules
+##########################################
+
 [*.{cs,csx,cake}]
+# C# 12 Primary constructors
+csharp_style_prefer_primary_constructors = true : suggestion
+
+# C# 12 Collection expressions
+csharp_style_prefer_collection_expression = when_types_exactly_match : suggestion
+
+# C# 12 Default lambda parameters
+csharp_style_prefer_default_literal = true : warning
+
 # 'var' preferences
 csharp_style_var_for_built_in_types = true : warning
 csharp_style_var_when_type_is_apparent = true : warning
 csharp_style_var_elsewhere = true : warning
+
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true : warning
 csharp_style_expression_bodied_constructors = true : warning
@@ -176,12 +174,15 @@ csharp_style_expression_bodied_indexers = true : warning
 csharp_style_expression_bodied_accessors = true : warning
 csharp_style_expression_bodied_lambdas = true : warning
 csharp_style_expression_bodied_local_functions = true : warning
-# Pattern matching preferences
+
+# Pattern matching preferences (enhanced in C# 12)
 csharp_style_pattern_matching_over_is_with_cast_check = true : warning
 csharp_style_pattern_matching_over_as_with_null_check = true : warning
 csharp_style_prefer_switch_expression = true : warning
 csharp_style_prefer_pattern_matching = true : warning
 csharp_style_prefer_not_pattern = true : warning
+csharp_style_prefer_extended_property_pattern = true : suggestion
+
 # Expression-level preferences
 csharp_style_inlined_variable_declaration = true : warning
 csharp_prefer_simple_default_expression = true : warning
@@ -190,85 +191,27 @@ csharp_style_deconstructed_variable_declaration = true : warning
 csharp_style_prefer_index_operator = true : warning
 csharp_style_prefer_range_operator = true : warning
 csharp_style_implicit_object_creation_when_type_is_apparent = true : warning
+csharp_style_prefer_utf8_string_literals = true : suggestion
+csharp_style_prefer_method_group_conversion = true : suggestion
+csharp_style_prefer_tuple_swap = true : suggestion
+csharp_style_prefer_readonly_struct = true : suggestion
+csharp_style_prefer_readonly_struct_member = true : suggestion
+
 # "Null" checking preferences
 csharp_style_throw_expression = true : warning
 csharp_style_conditional_delegate_call = true : warning
-# Enforce attributes on separate lines
-dotnet_diagnostic.SA1134.severity = warning
-# Alternative: Use IDE rules for attribute placement
-csharp_style_prefer_attributes_on_same_line = false
-dotnet_diagnostic.IDE0055.severity = warning
-
-# ReSharper/Rider specific settings for attribute placement
-resharper_place_attribute_on_same_line = false
-resharper_place_simple_attribute_on_same_line = false
-resharper_place_type_attribute_on_same_line = false
-resharper_place_method_attribute_on_same_line = false
-resharper_place_accessor_attribute_on_same_line = false
-resharper_place_field_attribute_on_same_line = false
-# Don't require localization for string literals
-dotnet_diagnostic.CA1303.severity = none
 
 # Code block preferences
 csharp_prefer_braces = when_multiline : warning
 csharp_prefer_simple_using_statement = true : suggestion
-dotnet_diagnostic.IDE0063.severity = suggestion
+
 # 'using' directive preferences
 csharp_using_directive_placement = inside_namespace : warning
+
 # Modifier preferences
 csharp_prefer_static_local_function = true : warning
-# Disable StyleCop rule for requiring braces for single-line statements
-dotnet_diagnostic.SA1503.severity = none
-resharper_redundant_block_braces_highlighting = do_not_show
-resharper_redundant_empty_declaration_highlighting = do_not_show
-resharper_remove_redundant_braces_highlighting = do_not_show
 
-##########################################
-# Unnecessary Code Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
-##########################################
-
-# .NET Unnecessary code rules
-[*.{cs,csx,cake,vb,vbx}]
-dotnet_code_quality_unused_parameters = all : warning
-dotnet_remove_unnecessary_suppression_exclusions = none : warning
-
-# C# Unnecessary code rules
-[*.{cs,csx,cake}]
-csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
-dotnet_diagnostic.IDE0058.severity = suggestion
-csharp_style_unused_value_assignment_preference = discard_variable : suggestion
-dotnet_diagnostic.IDE0059.severity = suggestion
-
-
-##########################################
-# Test suite rules
-##########################################
-# Exclude test files from certain rules
-[**/*Test.cs]
-dotnet_diagnostic.CA1515.severity = none
-
-##########################################
-# Formatting Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules
-##########################################
-
-# .NET formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
-[*.{cs,csx,cake,vb,vbx}]
-# Organize using directives
-dotnet_sort_system_directives_first = true
-# Dotnet namespace options
-dotnet_style_namespace_match_folder = true : suggestion
-dotnet_diagnostic.IDE0130.severity = suggestion
-# Disable requirement for qualified using directives
-dotnet_diagnostic.SA1135.severity = none
-
-# C# formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#c-formatting-rules
-[*.{cs,csx,cake}]
-# Newline options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#new-line-options
+# New line preferences
 csharp_new_line_before_open_brace = all
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
@@ -276,16 +219,17 @@ csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
 csharp_new_line_between_query_expression_clauses = true
-# Indentation options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#indentation-options
+csharp_new_line_before_binary_operators = false
+
+# Indentation preferences
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_indent_labels = no_change
 csharp_indent_block_contents = true
 csharp_indent_braces = false
 csharp_indent_case_contents_when_block = false
-# Spacing options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#spacing-options
+
+# Spacing preferences
 csharp_space_after_cast = false
 csharp_space_after_keywords_in_control_flow_statements = true
 csharp_space_between_parentheses = false
@@ -309,309 +253,211 @@ csharp_space_before_open_square_brackets = false
 csharp_space_between_empty_square_brackets = false
 csharp_space_between_square_brackets = false
 
-# Specifically for new keyword space
+# Wrap preferences
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true
+
+# Namespace preferences (C# 10+)
+csharp_style_namespace_declarations = file_scoped : warning
+
+##########################################
+# Dead Code Analysis
+##########################################
+
+# .NET dead code analysis
+dotnet_code_quality_unused_parameters = all : warning
+dotnet_remove_unnecessary_suppression_exclusions = none : warning
+
+# C# dead code analysis
+csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
+csharp_style_unused_value_assignment_preference = discard_variable : suggestion
+
+
+##########################################
+# Naming Rules
+##########################################
+
+# Styles
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.all_caps_style.capitalization = all_upper
+dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
+dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
+dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
+dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
+
+# Constants - SCREAMING_SNAKE_CASE or PascalCase
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_rule.constant_fields_should_be_all_caps.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_all_caps.style = all_caps_style
+dotnet_naming_rule.constant_fields_should_be_all_caps.severity = suggestion
+
+# Static readonly fields - PascalCase
+dotnet_naming_symbols.static_readonly_fields.applicable_kinds = field
+dotnet_naming_symbols.static_readonly_fields.applicable_accessibilities = *
+dotnet_naming_symbols.static_readonly_fields.required_modifiers = static, readonly
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.symbols = static_readonly_fields
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.static_readonly_fields_should_be_pascal_case.severity = warning
+
+# Private fields - camelCase
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private
+dotnet_naming_rule.private_fields_should_be_camel_case.symbols = private_fields
+dotnet_naming_rule.private_fields_should_be_camel_case.style = camel_case_style
+dotnet_naming_rule.private_fields_should_be_camel_case.severity = warning
+
+# Interfaces - PascalCase with I prefix
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.symbols = interfaces
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.style = prefix_interface_with_i_style
+dotnet_naming_rule.interfaces_should_be_prefixed_with_i.severity = warning
+
+# Type parameters - PascalCase with T prefix
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.symbols = type_parameters
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.style = prefix_type_parameters_with_t_style
+dotnet_naming_rule.type_parameters_should_be_prefixed_with_t.severity = warning
+
+# Methods, properties, events, classes, etc. - PascalCase
+dotnet_naming_symbols.pascal_case_symbols.applicable_kinds = namespace, class, struct, enum, delegate, event, method, property
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.symbols = pascal_case_symbols
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_rule.pascal_case_symbols_should_be_pascal_case.severity = warning
+
+# Parameters and locals - camelCase
+dotnet_naming_symbols.parameters_and_locals.applicable_kinds = parameter, local
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.symbols = parameters_and_locals
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.style = camel_case_style
+dotnet_naming_rule.parameters_and_locals_should_be_camel_case.severity = warning
+
+##########################################
+# ReSharper/Rider Specific Settings
+##########################################
+
+# Member ordering
+resharper_member_order = accessibility, kind
+resharper_arrange_member_access_first = true
+resharper_arrange_static_member_qualifier = true
+resharper_arrange_type_member_modifiers = true
+resharper_arrange_type_modifiers = true
+resharper_apply_member_ordering_pattern = true
+
+# Blank lines
+resharper_blank_lines_after_block_statements = 1
+resharper_blank_lines_around_single_line_type = 1
+resharper_blank_lines_around_field = 1
+resharper_blank_lines_around_property = 1
+resharper_blank_lines_around_method = 1
+resharper_blank_lines_after_using_list = 1
+resharper_keep_blank_lines_in_code = 1
+resharper_keep_blank_lines_in_declarations = 1
+resharper_remove_blank_lines_near_braces = true
+resharper_blank_lines_between_using_groups = 1
+
+# Spacing
 resharper_space_within_single_line_array_initializer_braces = true
 resharper_space_in_singleline_method = true
 resharper_space_after_new_expression = true
-resharper_space_after_type_parameter_constraint_colon = true
-dotnet_diagnostic.SA1000.severity = none
 
+# Attributes
+resharper_place_attribute_on_same_line = false
+resharper_place_simple_attribute_on_same_line = false
 
-# Wrap options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#wrap-options
-csharp_preserve_single_line_statements = false
-csharp_preserve_single_line_blocks = true
-# Namespace options
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#namespace-options
-csharp_style_namespace_declarations = file_scoped : warning
-# Disable StyleCop SA1118 (Parameter should not span multiple lines)
-dotnet_diagnostic.SA1118.severity = none
-
+# Format on save
+resharper_apply_on_save = true
 
 ##########################################
-# .NET Naming Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/naming-rules
+# StyleCop and Code Quality Overrides
 ##########################################
 
-[*.{cs,csx,cake,vb,vbx}]
-
-##########################################
-# Styles
-##########################################
-
-# camel_case_style - Define the camelCase style
-dotnet_naming_style.camel_case_style.capitalization = camel_case
-# pascal_case_style - Define the PascalCase style
-dotnet_naming_style.pascal_case_style.capitalization = pascal_case
-# first_upper_style - The first character must start with an upper-case character
-dotnet_naming_style.first_upper_style.capitalization = first_word_upper
-# prefix_interface_with_i_style - Interfaces must be PascalCase and the first character of an interface must be an 'I'
-dotnet_naming_style.prefix_interface_with_i_style.capitalization = pascal_case
-dotnet_naming_style.prefix_interface_with_i_style.required_prefix = I
-# prefix_type_parameters_with_t_style - Generic Type Parameters must be PascalCase and the first character must be a 'T'
-dotnet_naming_style.prefix_type_parameters_with_t_style.capitalization = pascal_case
-dotnet_naming_style.prefix_type_parameters_with_t_style.required_prefix = T
-# disallowed_style - Anything that has this style applied is marked as disallowed
-dotnet_naming_style.disallowed_style.capitalization = pascal_case
-dotnet_naming_style.disallowed_style.required_prefix = ____RULE_VIOLATION____
-dotnet_naming_style.disallowed_style.required_suffix = ____RULE_VIOLATION____
-# internal_error_style - This style should never occur... if it does, it indicates a bug in file or in the parser using the file
-dotnet_naming_style.internal_error_style.capitalization = pascal_case
-dotnet_naming_style.internal_error_style.required_prefix = ____INTERNAL_ERROR____
-dotnet_naming_style.internal_error_style.required_suffix = ____INTERNAL_ERROR____
-
-##########################################
-# .NET Design Guideline Field Naming Rules
-# Naming rules for fields follow the .NET Framework design guidelines
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/index
-##########################################
-
-# All public/protected/protected_internal constant fields must be PascalCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.public_protected_constant_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.public_protected_constant_fields_group.required_modifiers = const
-dotnet_naming_symbols.public_protected_constant_fields_group.applicable_kinds = field
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.symbols = public_protected_constant_fields_group
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.public_protected_constant_fields_must_be_pascal_case_rule.severity = warning
-
-# All public/protected/protected_internal static readonly fields must be PascalCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.required_modifiers = static, readonly
-dotnet_naming_symbols.public_protected_static_readonly_fields_group.applicable_kinds = field
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.symbols = public_protected_static_readonly_fields_group
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.public_protected_static_readonly_fields_must_be_pascal_case_rule.severity = warning
-
-# No other public/protected/protected_internal fields are allowed
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/field
-dotnet_naming_symbols.other_public_protected_fields_group.applicable_accessibilities = public, protected, protected_internal
-dotnet_naming_symbols.other_public_protected_fields_group.applicable_kinds = field
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.symbols = other_public_protected_fields_group
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.style = disallowed_style
-dotnet_naming_rule.other_public_protected_fields_disallowed_rule.severity = error
-
-##########################################
-# StyleCop Field Naming Rules
-# Naming rules for fields follow the StyleCop analyzers
-# This does not override any rules using disallowed_style above
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers
-##########################################
-
-# All constant fields must be PascalCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md
-dotnet_naming_style.all_caps_style.capitalization = all_upper
-dotnet_naming_symbols.stylecop_constant_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
-dotnet_naming_symbols.stylecop_constant_fields_group.required_modifiers = const
-dotnet_naming_symbols.stylecop_constant_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.symbols = stylecop_constant_fields_group
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.style = all_caps_style
-dotnet_naming_rule.stylecop_constant_fields_must_be_pascal_case_rule.severity = warning
-
-# All static readonly fields must be PascalCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1311.md
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected, private
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.required_modifiers = static, readonly
-dotnet_naming_symbols.stylecop_static_readonly_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.symbols = stylecop_static_readonly_fields_group
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.style = pascal_case_style
-dotnet_naming_rule.stylecop_static_readonly_fields_must_be_pascal_case_rule.severity = warning
-
-# No non-private instance fields are allowed
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1401.md
-dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_accessibilities = public, internal, protected_internal, protected, private_protected
-dotnet_naming_symbols.stylecop_fields_must_be_private_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.symbols = stylecop_fields_must_be_private_group
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.style = disallowed_style
-dotnet_naming_rule.stylecop_instance_fields_must_be_private_rule.severity = error
-
-# Private fields must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_accessibilities = private
-dotnet_naming_symbols.stylecop_private_fields_group.applicable_kinds = field
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.symbols = stylecop_private_fields_group
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.style = camel_case_style
-dotnet_naming_rule.stylecop_private_fields_must_be_camel_case_rule.severity = warning
-
-# Local variables must be camelCase
-# https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_accessibilities = local
-dotnet_naming_symbols.stylecop_local_fields_group.applicable_kinds = local
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.symbols = stylecop_local_fields_group
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.style = camel_case_style
-dotnet_naming_rule.stylecop_local_fields_must_be_camel_case_rule.severity = silent
-
-# This rule should never fire.  However, it's included for at least two purposes:
-# First, it helps to understand, reason about, and root-case certain types of issues, such as bugs in .editorconfig parsers.
-# Second, it helps to raise immediate awareness if a new field type is added (as occurred recently in C#).
-dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_accessibilities = *
-dotnet_naming_symbols.sanity_check_uncovered_field_case_group.applicable_kinds = field
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.symbols = sanity_check_uncovered_field_case_group
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.style = internal_error_style
-dotnet_naming_rule.sanity_check_uncovered_field_case_rule.severity = error
-
-
-##########################################
-# Other Naming Rules
-##########################################
-
-# All of the following must be PascalCase:
-# - Namespaces
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-namespaces
-#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
-# - Classes and Enumerations
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-#   https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1300.md
-# - Delegates
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces#names-of-common-types
-# - Constructors, Properties, Events, Methods
-#   https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-type-members
-dotnet_naming_symbols.element_group.applicable_kinds = namespace, class, enum, struct, delegate, event, method, property
-dotnet_naming_rule.element_rule.symbols = element_group
-dotnet_naming_rule.element_rule.style = pascal_case_style
-dotnet_naming_rule.element_rule.severity = warning
-
-# Interfaces use PascalCase and are prefixed with uppercase 'I'
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-dotnet_naming_symbols.interface_group.applicable_kinds = interface
-dotnet_naming_rule.interface_rule.symbols = interface_group
-dotnet_naming_rule.interface_rule.style = prefix_interface_with_i_style
-dotnet_naming_rule.interface_rule.severity = warning
-
-# Generics Type Parameters use PascalCase and are prefixed with uppercase 'T'
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces
-dotnet_naming_symbols.type_parameter_group.applicable_kinds = type_parameter
-dotnet_naming_rule.type_parameter_rule.symbols = type_parameter_group
-dotnet_naming_rule.type_parameter_rule.style = prefix_type_parameters_with_t_style
-dotnet_naming_rule.type_parameter_rule.severity = warning
-
-# Function parameters use camelCase
-# https://docs.microsoft.com/dotnet/standard/design-guidelines/naming-parameters
-dotnet_naming_symbols.parameters_group.applicable_kinds = parameter
-dotnet_naming_rule.parameters_rule.symbols = parameters_group
-dotnet_naming_rule.parameters_rule.style = camel_case_style
-dotnet_naming_rule.parameters_rule.severity = warning
-
-##########################################
-# License
-##########################################
-# The following applies as to the .editorconfig file ONLY, and is
-# included below for reference, per the requirements of the license
-# corresponding to this .editorconfig file.
-# See: https://github.com/RehanSaeed/EditorConfig
-#
-# MIT License
-#
-# Copyright (c) 2017-2019 Muhammad Rehan Saeed
-# Copyright (c) 2019 Henry Gabryjelski
-#
-# Permission is hereby granted, free of charge, to any
-# person obtaining a copy of this software and associated
-# documentation files (the "Software"), to deal in the
-# Software without restriction, including without limitation
-# the rights to use, copy, modify, merge, publish, distribute,
-# sublicense, and/or sell copies of the Software, and to permit
-# persons to whom the Software is furnished to do so, subject
-# to the following conditions:
-#
-# The above copyright notice and this permission notice shall be
-# included in all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-# HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-# OTHER DEALINGS IN THE SOFTWARE.
-##########################################
-
-
-#########################################################################################################
 # GdUnit4 specific overrides
-#########################################################################################################
-
-# Disable file header rules
+dotnet_diagnostic.SA1101.severity = none # Don't require 'this.' prefix
+dotnet_diagnostic.SA1636.severity = none
 dotnet_diagnostic.SA1633.severity = none # File must have header
 dotnet_diagnostic.SA1635.severity = none # File header must have copyright text
 dotnet_diagnostic.SA1637.severity = none # File header must contain file name
 dotnet_diagnostic.SA1638.severity = none # File header file name documentation must match file name
 dotnet_diagnostic.SA1634.severity = none # File header must show copyright
 
-# .NET formatting rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/formatting-rules#net-formatting-rules
-[*.{cs,csx,cake,vb,vbx}]
-# Organize using directives
-dotnet_separate_import_directive_groups = true
+# IDE rules overrides
+dotnet_diagnostic.IDE0130.severity = none # Namespace does not match folder structure
 
-dotnet_style_qualification_for_field = false : warning
-dotnet_style_qualification_for_property = false : warning
-dotnet_style_qualification_for_method = false : warning
-dotnet_style_qualification_for_event = false : warning
-dotnet_diagnostic.SA1101.severity = none
-
-dotnet_diagnostic.CA1822.severity = none
-
-# Don't require culture info for ToString()
-dotnet_diagnostic.CA1304.severity = none
-# Don't require a string format specifier.
-dotnet_diagnostic.CA1305.severity = none
-# Don't require culture info for Specify StringComparison for correctness
-dotnet_diagnostic.CA1310.severity = none
-# Don't require culture info for String.ToUpper() or String.ToLower() without specifying a culture.
-dotnet_diagnostic.CA1311.severity = none
-
-# Default severity for analyzer diagnostics with category 'Usage'
-dotnet_analyzer_diagnostic.category-Usage.severity = warning
-
-# allow constant arrays as arguments
-dotnet_diagnostic.CA1861.severity = none
-
-#### Define naming rules for constants
-
-# Disable StyleCop's underscore rule that prevents SCREAMING_SNAKE_CASE
+# Allow underscore in constant names (for SCREAMING_SNAKE_CASE)
 dotnet_diagnostic.SA1310.severity = none
 
+# Disable braces requirements for single-line statements
+dotnet_diagnostic.SA1503.severity = none
 
-# This will make everything that isn't already covered use PascalCase
-dotnet_naming_symbols.remaining_symbols.applicable_kinds = *
-dotnet_naming_symbols.remaining_symbols.applicable_accessibilities = *
+# Disable parameter spanning multiple lines requirement
+dotnet_diagnostic.SA1118.severity = none
 
-# Make everything else use PascalCase
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.symbols = remaining_symbols
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.style = pascal_case_style
-dotnet_naming_rule.remaining_symbols_should_be_pascal_case.severity = warning
+# Disable requirements for qualified using directives
+dotnet_diagnostic.SA1135.severity = none
 
-
-# ReSharper/Rider specific settings for blank lines
-resharper_blank_lines_after_block_statements = 1
-resharper_blank_lines_around_single_line_type = 1
-resharper_blank_lines_around_field = 1
-resharper_blank_lines_around_property = 1
-resharper_blank_lines_around_method = 1
-resharper_csharp_blank_lines_around_method = 1
-resharper_blank_lines_after_start_comment = 0
-resharper_blank_lines_after_block_comment = 0
-resharper_blank_lines_before_single_line_comment = 1
-resharper_blank_lines_after_using_list = 1
-resharper_keep_blank_lines_in_code = 1
-resharper_csharp_keep_blank_lines_in_code = 1
-resharper_remove_blank_lines_near_braces = true
-resharper_blank_lines_between_using_groups = 1
-
-# Ensure Rider keeps 1 blank line max in declarations
-resharper_keep_blank_lines_in_declarations = 1
-resharper_csharp_keep_blank_lines_in_declarations = 1
-dotnet_diagnostic.SA1507.severity = warning
-
-# ignore trailing commas
+# Allow trailing commas
 dotnet_diagnostic.SA1413.severity = none
 
+# Blank line rules
+dotnet_diagnostic.SA1507.severity = warning
 
-# Rider/ReSharper specific settings
-resharper_csharp_default_case_must_be_last = true
-resharper_empty_case_block_style = allowed
-resharper_default_case_seen_as_redundant = true
-resharper_redundant_empty_switch_section_highlighting = do_not_show
+# Don't require localization
+dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.CA1304.severity = none
+dotnet_diagnostic.CA1305.severity = none
+dotnet_diagnostic.CA1310.severity = none
+dotnet_diagnostic.CA1311.severity = none
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1861.severity = none # Allow constant arrays as arguments
+
+# Usage category warnings
+dotnet_analyzer_diagnostic.category-Usage.severity = warning
+
+# C# 12 collection expression rules (enable selectively)
+dotnet_diagnostic.IDE0290.severity = suggestion # Use primary constructor
+
+
+##########################################
+# Unnecessary Code Rules
+# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
+##########################################
+
+# .NET Unnecessary code rules
+[*.{cs,csx,cake,vb,vbx}]
+dotnet_code_quality_unused_parameters = all : warning
+dotnet_remove_unnecessary_suppression_exclusions = none : warning
+
+
+# C# Unnecessary code rules
+[*.{cs,csx,cake}]
+csharp_style_unused_value_expression_statement_preference = discard_variable : suggestion
+dotnet_diagnostic.IDE0058.severity = suggestion
+csharp_style_unused_value_assignment_preference = discard_variable : suggestion
+dotnet_diagnostic.IDE0059.severity = suggestion
+
+
+##########################################
+# Test Folder Exclusions
+##########################################
+
+# Godot-specific generated files
+[**/.godot/**/*.{cs,vb}]
+dotnet_analyzer_diagnostic.severity = silent
+dotnet_diagnostic.CS1591.severity = none
+dotnet_diagnostic.SA1633.severity = none
+
+##########################################
+# Test suite rules
+##########################################
+# Exclude test files from certain rules
+[**/*Test.cs]
+dotnet_diagnostic.CA1515.severity = none
+
+
+##########################################
+# License
+##########################################
+# Based on https://github.com/RehanSaeed/EditorConfig
+# MIT License - See original project for full license text

--- a/.github/actions/formatting_checks/.markdownlint.jsonc
+++ b/.github/actions/formatting_checks/.markdownlint.jsonc
@@ -1,0 +1,11 @@
+{
+    // Line length
+    "MD013": {
+        "line_length": 160,
+        "code_blocks": false,
+        "tables": false
+    },
+
+    "MD033": false,  // Allow all inline HTML
+    "showFound": true
+}

--- a/.github/actions/formatting_checks/.validationignore
+++ b/.github/actions/formatting_checks/.validationignore
@@ -1,0 +1,36 @@
+# Validation ignore patterns (gitignore-style syntax)
+# This file is used by the format-validation action
+
+# Dependencies
+node_modules/
+vendor/
+
+# Build outputs
+dist/
+build/
+*.min.js
+*.min.css
+
+# IDE files
+.vscode/
+.idea/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp
+*.temp
+*.log
+
+# Test fixtures or example files that might be intentionally malformed
+test/fixtures/
+examples/broken/
+
+# Third-party or generated files
+*.generated.yml
+*.auto.yaml
+
+# Ignore false positive detected invalid json
+stylecop.json

--- a/.github/actions/formatting_checks/.yamllint.yml
+++ b/.github/actions/formatting_checks/.yamllint.yml
@@ -1,0 +1,21 @@
+---
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
+extends: default
+
+rules:
+  line-length:
+    max: 160
+  document-start:
+    disable
+  new-lines:
+    type: unix
+  new-line-at-end-of-file:
+    level: warning
+  trailing-spaces:
+    level: warning
+  comments:
+    min-spaces-from-content: 1

--- a/.github/actions/formatting_checks/action.yml
+++ b/.github/actions/formatting_checks/action.yml
@@ -1,0 +1,50 @@
+name: "Formatting Checks"
+description: "Validate YAML, XML, Markdown, GitHub Actions workflows, and C# code formatting's"
+author: "MikeSchulze"
+
+inputs:
+  use-gitignore:
+    description: "Use .gitignore for validation exclusions"
+    required: false
+    default: "true"
+
+  actionlint-fail-on-error:
+    description: "Fail the action on actionlint errors"
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Validate YAML"
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        config_file: ".github/actions/formatting_checks/.yamllint.yml"
+
+    - name: "Validate GitHub Actions"
+      uses: raven-actions/actionlint@v2
+      with:
+        fail-on-error: ${{ inputs.actionlint-fail-on-error }}
+        matcher: true
+
+    - name: "Validate JSON and YAML"
+      uses: GrantBirki/json-yaml-validate@v3.3.2
+      with:
+        exclude_file: ".github/actions/formatting_checks/.validationignore"
+        use_gitignore: ${{ inputs.use-gitignore }}
+
+    - name: "Validate Markdown"
+      uses: DavidAnson/markdownlint-cli2-action@v20
+      with:
+        config: ".github/actions/formatting_checks/.markdownlint.jsonc"
+        globs: "**/*.md"
+
+    - name: "Setup .NET SDK"
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: "global.json"
+
+    - name: "Check Code Formatting"
+      shell: bash
+      run: |
+        dotnet format --verify-no-changes --verbosity diagnostic --exclude-diagnostics GdUnit0501 GdUnit0502

--- a/.github/workflows/ci-pr-publish-report.yml
+++ b/.github/workflows/ci-pr-publish-report.yml
@@ -1,13 +1,13 @@
-name: 'Publish Test Report'
-on:
+name: "Publish Test Report"
+on: # yamllint disable-line rule:truthy
   workflow_run:
-    workflows: [ 'ci-pr' ]  # runs after ci-pr workflow
+    workflows: ["ci-pr"]  # runs after ci-pr workflow
     types:
       - completed
   workflow_dispatch:
     inputs:
       workflow_run_id:
-        description: 'ID of the workflow run to download artifacts from.'
+        description: "ID of the workflow run to download artifacts from."
         required: true
         default: ''
 
@@ -37,8 +37,8 @@ jobs:
         uses: dorny/test-reporter@v2.1.1
         with:
           name: example_report
-          path: '**.trx'
+          path: "**.trx"
           reporter: dotnet-trx
-          fail-on-error: 'false'
-          fail-on-empty: 'false'
-          use-actions-summary: 'false'
+          fail-on-error: "false"
+          fail-on-empty: "false"
+          use-actions-summary: "false"

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,12 +1,11 @@
 name: ci-pr
 run-name: ${{ github.head_ref || github.ref_name }}-ci-pr
 
-on:
+on: # yamllint disable-line rule:truthy
   pull_request:
     paths-ignore:
-      - '**.jpg'
-      - '**.png'
-      - '**.md'
+      - "**.jpg"
+      - "**.png"
   workflow_dispatch:
 
 
@@ -19,25 +18,25 @@ jobs:
 
   setup-dotnet:
     name: "🔧 Setup .NET"
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-dotnet@v4
         with:
-          global-json-file: 'global.json'
+          global-json-file: "global.json"
 
   compile:
     name: "🔨 Compile Projects"
     needs: setup-dotnet
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: 'global.json'
+          global-json-file: "global.json"
 
       - name: "Build Projects"
         run: |
@@ -58,26 +57,17 @@ jobs:
             ${{ runner.os }}-build-${{ github.sha }}-${{ github.run_id }}
 
   style-check:
-    name: "🔍 Check Style: Examples"
-    needs: setup-dotnet
-    runs-on: 'ubuntu-24.04'
+    name: "📝 Linting & Formatting"
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 2
     steps:
       - uses: actions/checkout@v5
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: 'global.json'
-
-      - name: "Check Code Formatting"
-        if: ${{ !cancelled() }}
-        run: |
-          dotnet format --verify-no-changes --verbosity diagnostic --exclude-diagnostics GdUnit0501 GdUnit0502
+      - uses: ./.github/actions/formatting_checks
 
   example-tests:
     name: "🧪 Example Tests"
     needs: compile
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     timeout-minutes: 3
 
     steps:
@@ -85,7 +75,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
-          global-json-file: 'global.json'
+          global-json-file: "global.json"
 
       - name: "Restore Build Cache"
         if: ${{ !cancelled() }}
@@ -102,11 +92,11 @@ jobs:
       - name: "Install Godot Net"
         uses: ./.github/actions/godot-install
         with:
-          godot-version: '4.4.1'
+          godot-version: "4.4.1"
           godot-mono: true
-          godot-status-version: 'stable'
-          godot-bin-name: 'linux_x86_64'
-          godot-cache-path: '~/godot-linux'
+          godot-status-version: "stable"
+          godot-bin-name: "linux_x86_64"
+          godot-cache-path: "~/godot-linux"
 
       - name: "Run Tests"
         if: ${{ !cancelled() }}
@@ -129,9 +119,9 @@ jobs:
 
   finalize:
     if: ${{ !cancelled() }}
-    runs-on: 'ubuntu-24.04'
+    runs-on: "ubuntu-24.04"
     name: Final Results
-    needs: [ style-check, example-tests ]
+    needs: [style-check, example-tests]
     steps:
       - run: exit 1
         if: >-

--- a/.github/workflows/workflow-cleanup.yml
+++ b/.github/workflows/workflow-cleanup.yml
@@ -1,22 +1,22 @@
 name: cleanup-workflow-runs
 
-on:
+on: # yamllint disable-line rule:truthy
   schedule:
     - cron: "0 0 * * *" # GMT
   workflow_dispatch:
     inputs:
       days_to_keep:
-        description: 'Number of days to keep workflow runs'
+        description: "Number of days to keep workflow runs"
         required: false
-        default: '30'
+        default: "30"
         type: string
       delete_cancelled:
-        description: 'Delete cancelled workflow runs'
+        description: "Delete cancelled workflow runs"
         required: false
         default: true
         type: boolean
       delete_skipped:
-        description: 'Delete skipped workflow runs'
+        description: "Delete skipped workflow runs"
         required: false
         default: true
         type: boolean
@@ -34,15 +34,17 @@ jobs:
 
       - name: Set Environment Variables
         run: |
-          echo "DAYS_TO_KEEP=${{ github.event.inputs.days_to_keep || '5' }}" >> $GITHUB_ENV
-          echo "DELETE_CANCELLED=${{ github.event.inputs.delete_cancelled || 'true' }}" >> $GITHUB_ENV
-          echo "DELETE_SKIPPED=${{ github.event.inputs.delete_skipped || 'true' }}" >> $GITHUB_ENV
+          {
+            echo "DAYS_TO_KEEP=${{ github.event.inputs.days_to_keep || '5' }}"
+            echo "DELETE_CANCELLED=${{ github.event.inputs.delete_cancelled || 'true' }}"
+            echo "DELETE_SKIPPED=${{ github.event.inputs.delete_skipped || 'true' }}"
+          } >> "$GITHUB_ENV"
 
       - name: Cleanup of obsolete workflow runs
         uses: actions/github-script@v7
         with:
           script: |
-            const script = require('./.github/actions/workflow-cleanup/index.js')
+            const script = require("./.github/actions/workflow-cleanup/index.js")
             await script({
               github,
               context,

--- a/.idea/.idea.GdUnit4NetExamples/.idea/codeStyles/Project.xml
+++ b/.idea/.idea.GdUnit4NetExamples/.idea/codeStyles/Project.xml
@@ -5,6 +5,8 @@
         <option name="USE_TAB_CHARACTER" value="true" />
       </value>
     </option>
+    <option name="RIGHT_MARGIN" value="180" />
+    <option name="SOFT_MARGINS" value="140,180" />
     <stylecop>
       <option name="ENABLED" value="true" />
     </stylecop>

--- a/Examples/Advanced/README.md
+++ b/Examples/Advanced/README.md
@@ -1,10 +1,12 @@
 ﻿# Advanced Examples
 
-Welcome to the advanced gdUnit4Net examples! This section covers sophisticated testing techniques, professional configurations, and complex scenarios you'll encounter in real-world Godot projects.
+Welcome to the advanced gdUnit4Net examples! This section covers sophisticated testing techniques, professional configurations,
+and complex scenarios you'll encounter in real-world Godot projects.
 
 ## Prerequisites
 
 Before diving into advanced examples, ensure you understand:
+
 - Basic gdUnit4Net concepts from [Basics](../Basics/README.md)
 - Test project setup and configuration
 - Environment variables vs configuration files
@@ -13,6 +15,7 @@ Before diving into advanced examples, ensure you understand:
 ## Getting Started with Advanced Topics
 
 **Ready for more complex testing?** Explore in this order:
+
 1. [Global Test Settings](Setup/TestWithRunsettings/README.md) - Professional test configuration using .runsettings files
 2. [Compile-time Analysis](Setup/TestWithAnalyzers/README.md) - Static analysis and error prevention with gdUnit4.analyzers
 3. [Complex Test Scenarios](Tests/) - Advanced testing patterns and techniques
@@ -21,7 +24,7 @@ Before diving into advanced examples, ensure you understand:
 
 The advanced examples are organized into:
 
-```
+```shell
 ├── Setup/              # Advanced project configurations
 │   ├── TestWithRunsettings/    # Professional test settings configuration
 │   └── TestWithAnalyzers/      # Compile-time validation and code analysis 
@@ -36,23 +39,26 @@ The advanced examples are organized into:
 ## What Each Section Covers
 
 ### Setup/
+
 Professional project configurations for production-ready test environments:
 
 - **TestWithRunsettings**: Centralized configuration using .runsettings files
-    - Alternative to environment variables for team and CI/CD scenarios
-    - Multiple output formats and advanced logging
-    - Environment-specific configurations
-    - Better IDE integration and consistent team settings
+  - Alternative to environment variables for team and CI/CD scenarios
+  - Multiple output formats and advanced logging
+  - Environment-specific configurations
+  - Better IDE integration and consistent team settings
 
 - **TestWithAnalyzers**: Compile-time validation with gdUnit4.analyzers
-    - Static analysis to catch common testing mistakes at compile time
-    - Prevents runtime errors by detecting missing [RequireGodotRuntime] attributes
-    - IDE integration with real-time feedback and quick fixes
-    - Enforces gdUnit4Net best practices automatically
-    - Improves developer productivity and code quality
+  - Static analysis to catch common testing mistakes at compile time
+  - Prevents runtime errors by detecting missing [RequireGodotRuntime] attributes
+  - IDE integration with real-time feedback and quick fixes
+  - Enforces gdUnit4Net best practices automatically
+  - Improves developer productivity and code quality
 
 ### Tests/
+
 Advanced testing patterns and complex scenarios:
+
 - **Signal Testing**: Verifying Godot signal emissions and connections
 - **Scene Management**: Loading, instantiating, and testing complex scenes
 - **Async Testing**: Handling coroutines, timers, and async operations
@@ -62,24 +68,28 @@ Advanced testing patterns and complex scenarios:
 ## Key Concepts You'll Learn
 
 ### Configuration Management
+
 - Using .runsettings for team consistency and CI/CD integration
 - Environment-specific test configurations
 - Advanced logging and reporting options
 - Static analysis integration for error prevention
 
 ### Code Quality and Analysis
+
 - Compile-time validation of test code
 - Preventing common gdUnit4Net mistakes before runtime
 - IDE integration for immediate feedback
 - Enforcing coding standards and best practices
 
 ### Testing Strategies
+
 - Isolation techniques for complex dependencies
 - Testing interactions between multiple systems
 - Handling Godot-specific async patterns
 - Performance and load testing approaches
 
 ### Production Readiness
+
 - Test organization for large codebases
 - Continuous integration best practices
 - Test reporting and documentation
@@ -94,21 +104,24 @@ Advanced testing patterns and complex scenarios:
 
 ## When to Use Advanced Techniques
 
-### Use Advanced Configuration When:
+### Use Advanced Configuration When
+
 - ✅ Working in a team environment
 - ✅ Setting up CI/CD pipelines
 - ✅ Need multiple test output formats
 - ✅ Managing different environments (dev, staging, prod)
 - ✅ Want consistent configuration across team members
 
-### Use Static Analysis When:
+### Use Static Analysis When
+
 - ✅ Teams wanting to enforce gdUnit4Net best practices automatically
 - ✅ Projects requiring high test reliability and quality
 - ✅ Developers who want immediate feedback on testing mistakes
 - ✅ Codebases with many contributors to maintain consistency
 - ✅ CI/CD pipelines that should fail fast on test configuration errors
 
-### Use Advanced Testing When:
+### Use Advanced Testing When
+
 - ✅ Testing complex interactions between systems
 - ✅ Need to isolate dependencies
 - ✅ Testing performance-critical code
@@ -128,6 +141,7 @@ Advanced testing patterns and complex scenarios:
 ## Next Steps
 
 After mastering advanced techniques:
+
 - Apply learned concepts to your own projects
 - Combine .runsettings configuration with analyzer validation
 - Contribute your own advanced examples
@@ -137,6 +151,7 @@ After mastering advanced techniques:
 ## Contributing Advanced Examples
 
 Have an advanced testing scenario not covered here? We welcome contributions! Consider adding examples for:
+
 - Custom test adapters
 - Integration with external tools
 - Advanced CI/CD configurations

--- a/Examples/Advanced/Setup/TestWithAnalyzers/README.md
+++ b/Examples/Advanced/Setup/TestWithAnalyzers/README.md
@@ -5,15 +5,17 @@ An advanced example demonstrating how to use gdUnit4Net analyzers to catch commo
 ## What This Example Shows
 
 This project demonstrates:
+
 - **Compile-time error detection** using gdUnit4.analyzers
 - **Static analysis** to prevent runtime test failures
 - **Best practice enforcement** with automatic code validation
 - **IDE integration** with real-time feedback and quick fixes
 - **Developer productivity improvements** through early error detection
 
-## Why Use gdUnit4.analyzers?
+## Why Use gdUnit4.analyzers ?
 
-### Advantages of Compile-Time Analysis:
+### Advantages of Compile-Time Analysis
+
 - **Catch Errors Early**: Detect mistakes during compilation, not at runtime
 - **Clear Error Messages**: Get specific, actionable feedback about what's wrong
 - **IDE Integration**: Real-time warnings and suggestions as you type
@@ -21,7 +23,8 @@ This project demonstrates:
 - **Reduce Debugging Time**: Prevent common mistakes before they cause test failures
 - **Team Consistency**: Enforce coding standards across all developers
 
-### When to Use:
+### When to Use
+
 - ✅ Teams wanting to enforce gdUnit4Net best practices automatically
 - ✅ Projects requiring high test reliability and quality
 - ✅ Developers who want immediate feedback on testing mistakes
@@ -37,6 +40,7 @@ This project demonstrates:
 ## Key Analyzer Features
 
 ### 1. Missing [RequireGodotRuntime] Detection
+
 ```csharp
 // ❌ ANALYZER ERROR: Missing attribute when using Godot types
 [TestCase]
@@ -57,6 +61,7 @@ public void IsNodeNotNull()             // Analyzer approves this pattern
 ```
 
 ### 2. DataPoint and TestCase Validation
+
 ```csharp
 // ❌ ANALYZER ERROR: Invalid attribute combination
 [TestCase]
@@ -70,6 +75,7 @@ public void ValidTest() { }
 ```
 
 ### 3. Pure C# Test Validation
+
 ```csharp
 // ✅ CORRECT: Pure C# test doesn't need special attributes
 [TestCase]
@@ -83,6 +89,7 @@ public void TestPureCSharpObject()      // No Godot types = no warnings
 ## Analyzer Rules
 
 ### Core Rules
+
 | Rule ID | Description | Severity |
 |---------|-------------|----------|
 | **GdUnit0201** | Multiple TestCase attributes not allowed with DataPoint | Error |
@@ -90,6 +97,7 @@ public void TestPureCSharpObject()      // No Godot types = no warnings
 | **GdUnit0501** | Godot Runtime Required for Test Method | Error |
 
 ### What Gets Analyzed
+
 - **Godot Type Detection**: Node, Vector3, PackedScene, Resource, etc.
 - **Attribute Validation**: [RequireGodotRuntime], [TestCase], [TestSuite], [DataPoint]
 - **Attribute Combinations**: Prevents invalid combinations like multiple [TestCase] with [DataPoint]
@@ -98,18 +106,21 @@ public void TestPureCSharpObject()      // No Godot types = no warnings
 ## IDE Integration
 
 ### Visual Studio
+
 - **Real-time Analysis**: Squiggly underlines appear as you type
 - **Error List Integration**: All analyzer messages appear in Error List
 - **Quick Fixes**: Right-click → Quick Actions and Refactorings
 - **Build Integration**: Errors prevent successful compilation
 
 ### JetBrains Rider
+
 - **Inline Diagnostics**: Immediate feedback with detailed explanations
 - **Solution-wide Analysis**: Check entire solution for issues
 - **Inspection Results**: Dedicated tool window for all analyzer findings
 - **Context Actions**: Alt+Enter for quick fixes
 
 ### VS Code
+
 - **OmniSharp Integration**: Real-time diagnostics via C# extension
 - **Problems Panel**: All analyzer messages grouped by severity
 - **Code Actions**: Lightbulb icon for available fixes
@@ -118,7 +129,9 @@ public void TestPureCSharpObject()      // No Godot types = no warnings
 ## Configuration Options
 
 ### Enable/Disable Specific Rules
+
 Create `.editorconfig` in your project root:
+
 ```ini
 [*.cs]
 # Promote errors to warnings for stricter enforcement
@@ -129,7 +142,9 @@ dotnet_diagnostic.GdUnit0201.severity = none
 ```
 
 ### Project-Level Configuration
+
 Add to your `.csproj`:
+
 ```xml
 <PropertyGroup>
   <!-- Treat all analyzer warnings as errors -->
@@ -141,7 +156,9 @@ Add to your `.csproj`:
 ```
 
 ### Ruleset Files
+
 For complex projects, use `.ruleset` files:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="gdUnit4Net Rules" ToolsVersion="16.0">
@@ -156,7 +173,9 @@ For complex projects, use `.ruleset` files:
 ## Common Scenarios
 
 ### Scenario 1: New Developer Onboarding
+
 **Without Analyzers:**
+
 ```csharp
 [TestCase]  // Missing [RequireGodotRuntime]
 public void TestNode() 
@@ -165,21 +184,27 @@ public void TestNode()
     AssertThat(node).IsNotNull();
 }
 ```
-*Result: Confusing runtime errors, debugging sessions, frustrated developers*
+
+Result: *Confusing runtime errors, debugging sessions, frustrated developers*
 
 **With Analyzers:**
-```
+
+```cmd
 Error GdUnit0501: Test method 'TestNode' uses Godot types but is missing [RequireGodotRuntime] attribute
 ```
-*Result: Clear compile-time error with exact fix instructions*
+
+Result: *Clear compile-time error with exact fix instructions*
 
 ### Scenario 2: Refactoring Existing Tests
+
 When converting pure C# tests to use Godot types:
+
 - Analyzer immediately flags missing attributes
 - Provides suggestions for proper patterns
 - Prevents accidental runtime failures
 
 ### Scenario 3: CI/CD Integration
+
 ```bash
 # Build fails fast with clear analyzer errors
 dotnet build
@@ -190,27 +215,32 @@ dotnet build
 ## Performance Impact
 
 ### Compile Time
+
 - **Minimal Overhead**: Analyzers add ~5-10% to build time
 - **Incremental Analysis**: Only changed files are re-analyzed
 - **Parallel Execution**: Runs alongside normal compilation
 
 ### Runtime
+
 - **No Impact**: Analyzers only run during compilation
 - **Better Performance**: Prevents runtime errors that slow down test execution
 
 ## Troubleshooting
 
 **Analyzers not running?**
+
 - Verify `gdUnit4.analyzers` package is installed
 - Check IDE extensions are up to date
 - Restart IDE after adding analyzer package
 
 **False positives?**
+
 - Review analyzer rules documentation
 - Configure specific rules in `.editorconfig`
 - Report issues to gdUnit4Net repository
 
 **Missing errors in IDE but showing in build?**
+
 - Clear Visual Studio ComponentModelCache
 - Reload project files in IDE
 - Check OmniSharp restart in VS Code
@@ -229,6 +259,7 @@ dotnet build
 ## Next Steps
 
 After mastering analyzers:
+
 - Explore advanced .editorconfig rules
 - Set up custom analyzer configurations per environment
 - Integrate with code quality tools (SonarQube, etc.)

--- a/Examples/Advanced/Setup/TestWithRunsettings/README.md
+++ b/Examples/Advanced/Setup/TestWithRunsettings/README.md
@@ -5,6 +5,7 @@ An advanced example demonstrating how to configure gdUnit4Net test execution usi
 ## What This Example Shows
 
 This project demonstrates:
+
 - **Advanced test configuration** using `.runsettings` files
 - **Alternative to environment variables** for GODOT_BIN configuration
 - **Multiple output formats** (Console, HTML, TRX) for test results
@@ -13,14 +14,16 @@ This project demonstrates:
 
 ## Why Use .runsettings?
 
-### Advantages over Environment Variables:
+### Advantages over Environment Variables
+
 - **Version Control**: Configuration is committed with your code
 - **Team Consistency**: Everyone uses the same settings
 - **CI/CD Integration**: No need to configure environment variables in build systems
 - **Multiple Configurations**: Easy to have different settings for different environments
 - **IDE Integration**: Better support in Visual Studio, Rider, and VS Code
 
-### When to Use:
+### When to Use
+
 - ✅ Team projects where everyone needs consistent test configuration
 - ✅ CI/CD pipelines that need reliable test execution
 - ✅ Projects requiring specific test result formats
@@ -35,6 +38,7 @@ This project demonstrates:
 ## Key Configuration Sections
 
 ### 1. RunConfiguration
+
 ```xml
 <MaxCpuCount>1</MaxCpuCount>              <!-- Prevents Godot conflicts -->
 <TestSessionTimeout>1800000</TestSessionTimeout>  <!-- 30min timeout for long test suites -->
@@ -44,33 +48,39 @@ This project demonstrates:
 ```
 
 ### 2. LoggerRunSettings
+
 ```xml
 <Logger friendlyName="html" enabled="True">       <!-- Rich HTML reports -->
 <Logger friendlyName="trx" enabled="True">        <!-- CI/CD integration -->
 ```
 
 ### 3. GdUnit4 Specific
+
 ```xml
 <Parameters></Parameters>                         <!-- Custom Godot startup args -->
 <DisplayName>FullyQualifiedName</DisplayName>     <!-- Better test identification -->
 ```
-For more detailed information please read the [GdUnit Test Adapter Documentaion](https://github.com/MikeSchulze/gdUnit4Net/tree/master/TestAdapter)
 
+For more detailed information please read the [GdUnit Test Adapter Documentaion](https://github.com/MikeSchulze/gdUnit4Net/tree/master/TestAdapter)
 
 ## Running Tests with .runsettings
 
 ### Command Line
+
 ```bash
 dotnet test --settings .runsettings
 ```
 
 ### Visual Studio / Rider
+
 1. Right-click project → "Configure Run Settings"
 2. Select the `.runsettings` file in the project root
 3. Run tests normally
 
 ### VS Code
+
 Add to `.vscode/settings.json`:
+
 ```json
 {
     "dotnet-test-explorer.runSettingsPath": ".runsettings"
@@ -82,23 +92,27 @@ Add to `.vscode/settings.json`:
 ### For Different Environments
 
 **Development (.runsettings.dev):**
+
 ```xml
 <GODOT_BIN>C:\Godot\Godot.exe</GODOT_BIN>
 <Verbosity>detailed</Verbosity>
 ```
 
 **CI/CD (.runsettings.ci):**
+
 ```xml
 <GODOT_BIN>/usr/local/bin/godot</GODOT_BIN>
 <Parameters>--headless --disable-render-loop</Parameters>
 ```
 
 **Usage:**
+
 ```bash
 dotnet test --settings .runsettings.ci
 ```
 
 ### Common Godot Parameters
+
 - `--headless` - Run without GUI (CI/CD)
 - `--disable-render-loop` - Skip rendering (faster tests)
 - `--verbose` - Detailed Godot logging
@@ -107,6 +121,7 @@ dotnet test --settings .runsettings.ci
 ## Test Results
 
 After running tests, check the `./TestResults` directory for:
+
 - **test-result.html** - Rich, interactive HTML report
 - **test-result.trx** - Machine-readable format for CI/CD
 - **Console output** - Real-time feedback during execution
@@ -125,21 +140,25 @@ After running tests, check the `./TestResults` directory for:
 ## Troubleshooting
 
 **Tests not using .runsettings?**
+
 - Verify the file is in the project root
 - Check IDE settings point to the correct file
 - Use `--settings` parameter with `dotnet test`
 
 **Long execution times?**
+
 - Increase `TestSessionTimeout` for large test suites
 - Consider using `--headless` parameter for faster execution
 
 **Permission errors with GODOT_BIN path?**
+
 - Ensure the path in .runsettings uses forward slashes or escaped backslashes
 - Verify the Godot executable is accessible from the test environment
 
 ## Next Steps
 
 After mastering .runsettings configuration:
+
 - Explore environment-specific configurations
 - Learn about integrating with CI/CD systems
 - Check out the [Demos](../../../Demos/) for real-world examples

--- a/Examples/Advanced/Tests/SceneTesting/SceneUserInteractionsTest.cs
+++ b/Examples/Advanced/Tests/SceneTesting/SceneUserInteractionsTest.cs
@@ -2,6 +2,8 @@ namespace GdUnit4.Examples.Advanced.Tests.SceneTesting;
 
 using Godot;
 
+using Scenes;
+
 using static Assertions;
 
 /// <summary>

--- a/Examples/Advanced/Tests/SceneTesting/Scenes/TestSceneWithButton.cs
+++ b/Examples/Advanced/Tests/SceneTesting/Scenes/TestSceneWithButton.cs
@@ -1,4 +1,4 @@
-namespace GdUnit4.Examples.Advanced.Tests.SceneTesting;
+namespace GdUnit4.Examples.Advanced.Tests.SceneTesting.Scenes;
 
 using Godot;
 

--- a/Examples/Basics/README.md
+++ b/Examples/Basics/README.md
@@ -1,10 +1,12 @@
 ﻿# Basics Examples
 
-Welcome to the gdUnit4Net basics! This section provides step-by-step tutorials and fundamental examples to get you started with unit testing in Godot using C#.
+Welcome to the gdUnit4Net basics! This section provides step-by-step tutorials and fundamental examples to get you started with
+unit testing in Godot using C#.
 
 ## Prerequisites
 
 To follow these examples, you need:
+
 - Basic understanding of C# programming
 - Godot 4.4+ with .NET support installed
 - .NET 9.0 SDK
@@ -13,6 +15,7 @@ To follow these examples, you need:
 ## Getting Started
 
 **New to gdUnit4Net?** Follow this learning path:
+
 1. [Minimal Setup](Setup/MinimalTestProjectSetup/README.md) - Minimal example demonstrating the simplest possible gdUnit4Net test setup
 2. [Environment Setup](Setup/RequireGodotTestProjectSetup/README.md) - Essential project configuration and environment variables
 3. [Basic Test Writing](Tests/) - Master fundamental testing patterns and techniques
@@ -21,7 +24,7 @@ To follow these examples, you need:
 
 The basic examples are organized into:
 
-```
+```shell
 ├── Setup/              # Project setup and configuration examples
 │   ├── MinimalTestProjectSetup/        # Pure .NET testing setup
 │   └── RequireGodotTestProjectSetup/   # Godot runtime testing setup
@@ -36,14 +39,18 @@ The basic examples are organized into:
 ## What Each Section Covers
 
 ### Setup/
+
 Learn how to configure different types of test projects:
+
 - **MinimalTestProjectSetup**: Testing pure .NET code without Godot dependencies
 - **RequireGodotTestProjectSetup**: Testing Godot-specific classes and functionality
 - Environment setup and configuration differences
 - Project file structure and package requirements
 
 ### Tests/
+
 Master fundamental testing concepts and patterns:
+
 - **Assertion Examples**: Using AssertThat() with different data types
 - **Test Attributes**: Understanding [TestSuite], [TestCase], lifecycle methods
 - **Simple Godot Node Test**: Basic testing of Godot objects and types
@@ -52,18 +59,21 @@ Master fundamental testing concepts and patterns:
 ## Key Concepts You'll Learn
 
 ### Project Setup
+
 - Difference between .NET-only and Godot runtime testing
 - Environment variable configuration
 - Required NuGet packages
 - Basic .csproj structure
 
 ### Testing Fundamentals
+
 - Writing your first test methods [TestCase]
 - Understanding [TestSuite] and [TestCase] attributes
 - Basic assertion patterns with AssertThat()
 - Test organization and naming conventions
 
 ### Godot-Specific Testing
+
 - Using [RequireGodotRuntime] for Godot-specific tests
 - Testing Godot objects (Vector3, Node, GodotObject)
 - Memory management with AutoFree()
@@ -80,7 +90,7 @@ Master fundamental testing concepts and patterns:
 
 ## When to Use Each Setup
 
-### Start with Basics When:
+### Start with Basics When
 
 - ✅ New to gdUnit4Net or unit testing
 - ✅ Setting up your first test project
@@ -105,13 +115,15 @@ A: Yes! Always call Free() on Godot objects in tests to prevent memory leaks.
 ## Test Execution Overview
 
 ### Pure .NET Tests (MinimalTestProjectSetup)
-```
+
+```cmd
 Build → Run Tests → Results
 ~2-5 seconds total
 ```
 
 ### Godot Runtime Tests (RequireGodotTestProjectSetup)
-```
+
+```cmd
 Build → Start Godot → Initialize Runtime → Run Tests → Results
 ~30+ seconds first run, ~10-15 seconds subsequent runs
 ```
@@ -119,6 +131,7 @@ Build → Start Godot → Initialize Runtime → Run Tests → Results
 ## Essential Testing Patterns
 
 ### Basic Assertion
+
 ```csharp
 [TestCase]
 public void BasicAssertion()
@@ -128,6 +141,7 @@ public void BasicAssertion()
 ```
 
 ### Godot Object Testing
+
 ```csharp
 [TestCase]
 [RequireGodotRuntime]
@@ -140,6 +154,7 @@ public void GodotObjectTest()
 ```
 
 ### Test Class Structure
+
 ```csharp
 [TestSuite]
 public class MyTestClass
@@ -149,20 +164,25 @@ public class MyTestClass
 }
 ```
 
-## Troubleshooting Common Issues
+## Troubleshooting
 
-**"No test is available" Error**
+### Common Issues
+
+#### "No test is available" Error
+
 - Check if GODOT_BIN environment variable is set (for Godot runtime tests)
 - Verify test methods have [TestCase] attribute
 - Ensure test class has [TestSuite] attribute
 
-**Build Errors After Project Conversion**
+#### Build Errors After Project Conversion
+
 - Delete obj/ and bin/ directories
 - Run `dotnet build` again
 
 ## Next Steps
 
 After mastering the basics:
+
 - Explore [Advanced examples](../Advanced/) for professional configurations
 - Learn about complex testing scenarios and patterns
 - Practice with your own Godot projects
@@ -171,6 +191,7 @@ After mastering the basics:
 ## Contributing Basic Examples
 
 Found something confusing or missing? We welcome contributions! Consider adding examples for:
+
 - Additional assertion types
 - Common testing scenarios
 - Beginner-friendly explanations

--- a/Examples/Basics/Setup/MinimalTestProjectSetup/README.md
+++ b/Examples/Basics/Setup/MinimalTestProjectSetup/README.md
@@ -7,6 +7,7 @@ A minimal example demonstrating the simplest possible gdUnit4Net test setup in a
 ## What This Example Shows
 
 This project demonstrates:
+
 - **Minimal project structure** for gdUnit4Net testing
 - **Basic .csproj configuration** with essential properties and packages
 - **Simple test class** with a basic assertion
@@ -34,6 +35,7 @@ This project demonstrates:
 ## Next Steps
 
 After understanding this minimal setup:
+
 - Explore more assertion types in the [Basics/Tests](../../Tests/) folder
 - See real-world examples in the [Demos](../../../Demos/) folder
 - Check the [Advanced](../../Advanced/) examples for complex scenarios

--- a/Examples/Basics/Setup/RequireGodotTestProjectSetup/README.md
+++ b/Examples/Basics/Setup/RequireGodotTestProjectSetup/README.md
@@ -7,6 +7,7 @@ An example demonstrating how to test Godot-specific classes and functionality th
 ## What This Example Shows
 
 This project demonstrates:
+
 - **Setting up test environment** for Godot runtime testing (GODOT_BIN)
 - **Testing Godot-derived classes** that inherit from GodotObject, Node, etc.
 - **Using [RequireGodotRuntime]** attribute for tests that need Godot's runtime
@@ -20,17 +21,20 @@ This project demonstrates:
 Tests that use `[RequireGodotRuntime]` need the Godot executable to be available. Set the `GODOT_BIN` environment variable:
 
 **Windows:**
+
 ```cmd
 set GODOT_BIN=C:\path\to\Godot_v4.4.1-stable_mono_win64.exe
 ```
 
 **Linux/macOS:**
+
 ```bash
 export GODOT_BIN=/path/to/Godot_v4.4.1-stable_mono_linux64
 ```
 
 **Without this environment variable, you'll see:**
-```
+
+```cmd
 Godot runtime is not configured. The environment variable 'GODOT_BIN' is not set or empty. 
 Please set it to the Godot executable path.
 No test is available in [...].dll
@@ -73,13 +77,13 @@ No test is available in [...].dll
 **⚠️ Important**: Test execution will take longer than regular .NET tests due to Godot runtime overhead:
 
 - **First Run**: Expect 30+ seconds as gdUnit4Net will:
-    - Install the test runner to `RequireGodotTestProjectSetup/gdunit4_testadapter_v5/` (from gdUnit4.api package)
-    - Recompile the project with the test adapter
+  - Install the test runner to `RequireGodotTestProjectSetup/gdunit4_testadapter_v5/` (from gdUnit4.api package)
+  - Recompile the project with the test adapter
 
 - **Subsequent Runs**: Still slower than pure .NET tests (~10-15 seconds) because:
-    - Godot editor needs to start and initialize
-    - Test runner must load the Godot runtime environment
-    - Each test requiring `[RequireGodotRuntime]` runs in the Godot context
+  - Godot editor needs to start and initialize
+  - Test runner must load the Godot runtime environment
+  - Each test requiring `[RequireGodotRuntime]` runs in the Godot context
 
 This is normal behavior - the trade-off for being able to test Godot-specific functionality.
 
@@ -99,6 +103,7 @@ Always call `Free()` on Godot objects after testing to prevent memory leaks.
 ## Next Steps
 
 After understanding Godot runtime testing:
+
 - Explore testing Nodes and Scenes in [Advanced examples](../../Advanced/)
 - See real-world Godot testing in the [Demos](../../../Demos/) folder
 - Learn about testing signals and Godot-specific functionality

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,10 +1,12 @@
 ﻿# Examples
 
-Welcome to the gdUnit4Net examples! This section contains hands-on examples and tutorials to help you learn unit testing with gdUnit4Net in Godot.
+Welcome to the gdUnit4Net examples! This section contains hands-on examples and tutorials to help you learn unit testing
+with gdUnit4Net in Godot.
 
 ## Getting Started
 
 **New to gdUnit4Net?** Start here:
+
 1. [Basics](Basics/README.md) - Basic step-by-step tutorials and fundamental examples to get you started with unit testing
 2. [Advanced](Advanced/README.md) - Ophisticated testing techniques, professional configurations, and complex scenarios
 3. [Demos](../Demos/) - Complete project examples
@@ -13,7 +15,7 @@ Welcome to the gdUnit4Net examples! This section contains hands-on examples and 
 
 The examples are organized into the following structure:
 
-```
+```shell
 ├── Basics/                   # Beginner examples and tutorials
 │   ├── Setup/                # Project setup examples
 │   └── Tests/                # Basic unit test patterns and techniques
@@ -28,27 +30,34 @@ The examples are organized into the following structure:
 ## What Each Section Contains
 
 ### Basics/
+
 Perfect for developers new to unit testing or gdUnit4Net:
+
 - Setting up your first test project
 - Writing simple assertions
 - Understanding test attributes and lifecycle
 - Testing basic Godot objects and .NET types
 
 ### Advanced/
+
 For developers ready to tackle complex scenarios:
+
 - Advanced test configurations
 - Mocking and test doubles
 - Testing async operations
 - Performance and integration testing
 
 ### Demos/
+
 Real-world examples showing complete projects with comprehensive test suites:
+
 - **MenuDemo2D**: UI testing, button interactions, menu navigation
 - **RoomDemo3D**: 3D physics, player movement, collision detection
 
 ## Running the Examples
 
 Before you start, you need to clone the repository.
+
 ```bash
 git clone https://github.com/MikeSchulze/gdUnit4NetExamples.git
 cd gdUnit4NetExamples
@@ -94,6 +103,7 @@ dotnet build
 ## Next Steps
 
 After running the examples:
+
 - Explore the [detailed documentation](../docs/) for in-depth guides
 - Check out the [gdUnit4Net API documentation](https://github.com/MikeSchulze/gdUnit4Net)
 - Try creating your own tests based on the patterns you've learned

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
   <img src="assets/wip.png" alt="" width="50%"></br>
 </p>
 
-This repository contains example projects and test cases demonstrating how to use [gdUnit4Net](https://github.com/MikeSchulze/gdUnit4Net), a C# unit testing framework for Godot 4.
+This repository contains example projects and test cases demonstrating how to use [gdUnit4Net](https://github.com/MikeSchulze/gdUnit4Net),
+a C# unit testing framework for Godot4.
 
 ## Table of Contents
 
@@ -11,10 +12,10 @@ This repository contains example projects and test cases demonstrating how to us
 - [Requirements & Prerequisites](#requirements--prerequisites)
 - [Installation](#installation)
 - [Code Quality and Best Practices](#code-quality-and-best-practices)
-    - [Build Configuration](#build-configuration)
-    - [Code Style Enforcement](#code-style-enforcement)
-    - [Documentation Practices](#documentation-practices)
-    - [IDE Integration](#ide-integration)
+  - [Build Configuration](#build-configuration)
+  - [Code Style Enforcement](#code-style-enforcement)
+  - [Documentation Practices](#documentation-practices)
+  - [IDE Integration](#ide-integration)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -32,9 +33,9 @@ To work with this project, you'll need:
 - **Godot Engine**: Version 4.4.x with .NET/Mono support enabled
 - **.NET SDK**: Version 9.0.x
 - **IDE**: One of the following:
-    - Visual Studio 2022
-    - Visual Studio Code with C# extension
-    - JetBrains Rider (recommended for best testing experience)
+  - Visual Studio 2022
+  - Visual Studio Code with C# extension
+  - JetBrains Rider (recommended for best testing experience)
 
 ### Project Specifications
 
@@ -50,17 +51,20 @@ To work with this project, you'll need:
 ### Setup Steps
 
 1. **Clone the repository**
+
    ```bash
    git clone https://github.com/MikeSchulze/gdUnit4NetExamples.git
    cd gdUnit4NetExamples
    ```
 
 2. **Verify your installed .NET SDKs**
+
    ```bash
    dotnet --list-sdks
     7.0.404 [C:\Program Files\dotnet\sdk]
     8.0.411 [C:\Program Files\dotnet\sdk]
    ```
+
    Ensure .NET 9.0.x is listed among the installed SDKs.
 
    **If .NET 9.0 is not installed:**
@@ -70,6 +74,7 @@ To work with this project, you'll need:
    b. Follow the installation instructions for your operating system
 
    c. After installation, verify with:
+
    ```bash
    dotnet --list-sdks
     7.0.404 [C:\Program Files\dotnet\sdk]
@@ -78,9 +83,11 @@ To work with this project, you'll need:
    ```
 
 3. **Build the project**
+
    ```bash
    dotnet build
    ```
+
    This will restore all required NuGet packages and build the project.
 
 ---
@@ -89,14 +96,15 @@ To work with this project, you'll need:
 
 ## Code Quality and Best Practices
 
-This example project demonstrates not only how to use GdUnit4Net for testing but also showcases best practices for maintaining high-quality C# code in Godot projects.
+This example project demonstrates not only how to use GdUnit4Net for testing but also showcases best practices for maintaining high-quality
+C# code in Godot projects.
 
 ### Build Configuration
 
 #### Directory.Build.props
 
-We use a `Directory.Build.props` file to centralize common build settings across all projects. This ensures consistent code quality enforcement without having to duplicate settings
-in each project file.
+We use a `Directory.Build.props` file to centralize common build settings across all projects.
+This ensures consistent code quality enforcement without having to duplicate settings in each project file.
 
 Key features:
 
@@ -121,8 +129,8 @@ Key features:
 
 #### .editorconfig
 
-The repository includes a comprehensive `.editorconfig` file that defines coding standards. This file is automatically recognized by Visual Studio, VS Code, Rider, and other
-editors that support the EditorConfig standard.
+The repository includes a comprehensive `.editorconfig` file that defines coding standards.
+This file is automatically recognized by Visual Studio, VS Code, Rider, and other editors that support the EditorConfig standard.
 
 Benefits:
 


### PR DESCRIPTION
# Why
We want to have consistent formatted files and needs an action to verify it.

# What
- Adding extended formatting linting checks
- Update `.editorconfig` to GdUnit4 rules
- Fix linting errors
- Fix formatting errors